### PR TITLE
add: sortLike

### DIFF
--- a/packages/unmutable-docs/src/data/ApiData.js
+++ b/packages/unmutable-docs/src/data/ApiData.js
@@ -394,6 +394,11 @@ update(updater: (collection: any) => any) => (collection) => newCollection`,
                         description: "Like sortBy(), but guarantees that items are stable sorted, meaning that the order of items that produce equivalent sort values are retained."
                     },
                     {
+                        name: "sortLike",
+                        definition: "sortLike(\n    idCollection,\n    idMapper: (item) => id,\n    unmatchedIds?: boolean,\n    unmatchedItems?: boolean\n) => (collection) => newCollection",
+                        description: "This will sort `collection` so it matches the order of ids specified in `idCollection`. The `idMapper` function is used to generate ids for each item in `collection`, which are then compared against `idCollection`.\n\nAny ids in `idCollection` that have no match in `collection` will not be output, or if `unmatchedIds` is true then they will be output as `undefined`.\n\nIf `unmatched` is `true`, all items in `collection` that were not matched by `idCollection` will be output at the end of the returned collection, in the order they appear in the input `collection`."
+                    },
+                    {
                         name: "groupBy",
                         description: ""
                     },

--- a/packages/unmutable/.gitignore
+++ b/packages/unmutable/.gitignore
@@ -122,6 +122,7 @@
 /some.js
 /sort.js
 /sortBy.js
+/sortLike.js
 /splice.js
 /stableSortBy.js
 /startsWith.js

--- a/packages/unmutable/index.js
+++ b/packages/unmutable/index.js
@@ -96,6 +96,7 @@ export {default as slice} from './lib/slice';
 export {default as some} from './lib/some';
 export {default as sortBy} from './lib/sortBy';
 export {default as sort} from './lib/sort';
+export {default as sortLike} from './lib/sortLike';
 export {default as splice} from './lib/splice';
 export {default as stableSortBy} from './lib/stableSortBy';
 export {default as startsWith} from './lib/startsWith';

--- a/packages/unmutable/package.json
+++ b/packages/unmutable/package.json
@@ -125,6 +125,7 @@
     "some.js",
     "sort.js",
     "sortBy.js",
+    "sortLike.js",
     "splice.js",
     "stableSortBy.js",
     "startsWith.js",

--- a/packages/unmutable/src/__test__/sortLike-test.js
+++ b/packages/unmutable/src/__test__/sortLike-test.js
@@ -1,0 +1,76 @@
+// @flow
+import get from '../get';
+import sortLike from '../sortLike';
+
+let items = [
+    {id: 1, name: 'A'},
+    {id: 2, name: 'B'},
+    {id: 3, name: 'C'}
+];
+
+test(`sortLike() should work if keys are the same as input`, () => {
+    expect(sortLike([1,2,3], ii => ii.id)(items)).toEqual([
+        {id: 1, name: 'A'},
+        {id: 2, name: 'B'},
+        {id: 3, name: 'C'}
+    ]);
+});
+
+test(`sortLike() should work if keys are redordered from input`, () => {
+    expect(sortLike([3,2,1], ii => ii.id)(items)).toEqual([
+        {id: 3, name: 'C'},
+        {id: 2, name: 'B'},
+        {id: 1, name: 'A'}
+    ]);
+});
+
+test(`sortLike() should work if keys are trimmed from input`, () => {
+    expect(sortLike([2,1], ii => ii.id)(items)).toEqual([
+        {id: 2, name: 'B'},
+        {id: 1, name: 'A'}
+    ]);
+});
+
+test(`sortLike() should skip where keys dont exist`, () => {
+    expect(sortLike([1,4,5,3], ii => ii.id)(items)).toEqual([
+        {id: 1, name: 'A'},
+        {id: 3, name: 'C'}
+    ]);
+});
+
+
+test(`sortLike() should create undefined where keys dont exist if unmatchedIds = true`, () => {
+    expect(sortLike([1,4,5,3], ii => ii.id, true)(items)).toEqual([
+        {id: 1, name: 'A'},
+        undefined,
+        undefined,
+        {id: 3, name: 'C'}
+    ]);
+});
+
+test(`sortLike() should output item more than once if keyed more than once`, () => {
+    expect(sortLike([1,1,1], ii => ii.id)(items)).toEqual([
+        {id: 1, name: 'A'},
+        {id: 1, name: 'A'},
+        {id: 1, name: 'A'}
+    ]);
+});
+
+test(`sortLike() should output unmatched if instructed`, () => {
+    expect(sortLike([3], ii => ii.id, false, true)(items)).toEqual([
+        {id: 3, name: 'C'},
+        {id: 1, name: 'A'},
+        {id: 2, name: 'B'}
+    ]);
+});
+
+test(`sortLike() should output unmatched and create undefined where keys dont exist`, () => {
+    expect(sortLike([1,3,4,5], ii => ii.id, true, true)(items)).toEqual([
+        {id: 1, name: 'A'},
+        {id: 3, name: 'C'},
+        undefined,
+        undefined,
+        {id: 2, name: 'B'}
+    ]);
+});
+

--- a/packages/unmutable/src/sortLike.js
+++ b/packages/unmutable/src/sortLike.js
@@ -1,0 +1,36 @@
+// @flow
+import prep from './internal/unmutable';
+import forEach from './forEach';
+import pipeWith from './pipeWith';
+import map from './map';
+import concat from './concat';
+import filter from './filter';
+
+const ID_NO_MATCH = Symbol('ID_NO_MATCH');
+
+export default prep({
+    name: 'sortLike',
+    all: (like: any, idMapper: Function, unmatchedIds: boolean = false, unmatchedItems: boolean = false) => (value: *): * => {
+        let valueById = new Map();
+        forEach(item => {
+            valueById.set(idMapper(item), item);
+        })(value);
+
+        let matchedItems = pipeWith(
+            like,
+            map(id => valueById.has(id) ? valueById.get(id) : ID_NO_MATCH),
+            unmatchedIds
+                ? map(item => item === ID_NO_MATCH ? undefined : item)
+                : filter(item => item !== ID_NO_MATCH)
+        );
+
+        if(!unmatchedItems) return matchedItems;
+
+        let likeById = new Map();
+        forEach(id => {
+            likeById.set(id, true);
+        })(like);
+
+        return concat(filter(item => !likeById.get(idMapper(item)))(value))(matchedItems);
+    }
+});


### PR DESCRIPTION
- Add `sortLike`
  - Like a synchronous, less cool version of one usage of `zipDiff` in https://github.com/92green/92green-stream/tree/master/packages/92green-rxjs